### PR TITLE
ci: deploy example to GitHub Pages on every push to master

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,47 @@
+name: Deploy Example to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      # Library devDeps must be installed so the example build can resolve
+      # @angular/core from the root node_modules (path alias ../src/public-api.ts)
+      - name: Install library dependencies
+        run: npm ci
+
+      - name: Install example dependencies
+        run: npm ci
+        working-directory: example
+
+      - name: Build example
+        run: npx ng build --base-href /angular-draggable/ --configuration production
+        working-directory: example
+
+      - name: Add .nojekyll
+        run: touch example/dist/example/browser/.nojekyll
+
+      - name: Deploy to gh-pages branch
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: example/dist/example/browser
+          force_orphan: true
+          commit_message: 'deploy: ${{ github.sha }}'


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy-gh-pages.yml` — builds the Angular 19 example app and pushes it to the `gh-pages` branch on every push to `master`
- Initial build already deployed manually to kick things off

## How it works

1. Installs root `devDependencies` so the esbuild bundler can resolve `@angular/core` via the `../src` path alias in `example/tsconfig.json`
2. Installs `example/` dependencies
3. Builds with `--base-href /angular-draggable/ --configuration production`
4. Deploys `example/dist/example/browser/` to the `gh-pages` branch via `peaceiris/actions-gh-pages@v4`

## Live URL

https://ajaysinghj8.github.io/angular-draggable/

## Test plan

- [ ] Merge and confirm the Actions workflow runs green
- [ ] Visit the live URL and verify the demo loads and drag/drop works

🤖 Generated with [Claude Code](https://claude.com/claude-code)